### PR TITLE
重力加速度で歩数計の初期値が1になるのを修正

### DIFF
--- a/poketch/pedometer.h
+++ b/poketch/pedometer.h
@@ -30,7 +30,7 @@ private:
     const float LOW_PATH = 0.1F;
 
     float _threshold = 1.10F;
-    float _beforeA = 0.0F;
+    float _beforeA = 1.0F;
     bool _isUnder = false;
     float _maxA = 0.0F;
     float _minA = 100.0F;


### PR DESCRIPTION
_beforeA の初期値が0であることで電源オン時に重力加速度の影響でカウントが進んで、歩数計の初期値が1になるのを修正しました。
_beforeA = 1.0F と変更します。